### PR TITLE
Turn on requesting of Dialogmoter for Isdialogmote

### DIFF
--- a/server/proxy.js
+++ b/server/proxy.js
@@ -43,6 +43,10 @@ const proxyExternalHost = (host, accessToken, parseReqBody) =>
         (pathFromRequest ? pathFromRequest : "") +
         (queryString ? "?" + queryString : "");
 
+      if (host === Config.auth.isdialogmote.host) {
+        const newPathIsdialogmote = newPath.replace("isdialogmote/", "");
+        return `https://${newPathIsdialogmote}`;
+      }
       return `https://${newPath}`;
     },
     proxyErrorHandler: (err, res, next) => {

--- a/src/containers/EnhetensMoterContainer.tsx
+++ b/src/containers/EnhetensMoterContainer.tsx
@@ -32,8 +32,7 @@ const EnhetensMoterContainer = (): ReactElement => {
   useEffect(() => {
     if (aktivEnhet !== hentetEnhet) {
       dispatch(hentEnhetsMoter(aktivEnhet));
-      // TODO: Add after implementing V2 of API in ISdialogmote
-      // dispatch(hentDialogmoter(aktivEnhet));
+      dispatch(hentDialogmoter(aktivEnhet));
     }
   }, [aktivEnhet, hentetEnhet]);
 


### PR DESCRIPTION
Request Dialogmoter from Isdialogmote again after version 2 of the API in Isdialogmote supporting AzureAd v2 with OBO-token has been added.