### PR TITLE
Henter dialogmoter

### DIFF
--- a/mock/mockDialogmoter.js
+++ b/mock/mockDialogmoter.js
@@ -3,8 +3,6 @@ function getDefaultDialogmote() {
     uuid: "85902bc3-86d5-4571-b06a-35e098f86927",
     createdAt: "2021-02-26T12:31:46.126",
     updatedAt: "2021-02-26T12:31:46.126",
-    planlagtMoteUuid: "85902bc3-86d5-4571-b06a-35e098f86927",
-    planlagtMoteBekreftetTidspunkt: "2019-11-26T13:31:46.126",
     status: "INNKALT",
     opprettetAv: "Z990197",
     tildeltVeilederIdent: "Z990197",
@@ -30,14 +28,18 @@ function getDefaultDialogmote() {
       lederNavn: "Korrupt Bolle",
       lederEpost: "korrupt.bolle@nav.no",
       type: "ARBEIDSGIVER",
+      varselList: [
+        {
+          uuid: "85902bc3-86d5-4571-b06a-35e098f86931",
+          createdAt: "2021-02-26T12:31:46.126",
+          varselType: "INNKALT",
+          lestDato: "2021-02-27T13:31:46.126",
+        },
+      ],
     },
-    tidStedList: [
-      {
-        uuid: "85902bc3-86d5-4571-b06a-35e098f86930",
-        sted: "Månen",
-        tid: "2021-03-26T12:31:46.126",
-      },
-    ],
+    sted: "Månen",
+    tid: "2021-03-26T12:31:46.126",
+    videoLink: "https://meet.google.com/xyz",
   };
 }
 

--- a/mock/mockEndepunkter.js
+++ b/mock/mockEndepunkter.js
@@ -84,7 +84,7 @@ function mockEndepunkter(server) {
   );
 
   server.get(
-    "/isdialogmote/api/v2/dialogmote/enhet",
+    "/isdialogmote/api/v2/dialogmote/enhet/:enhetId",
     Auth.ensureAuthenticated(),
     (req, res) => {
       res.setHeader("Content-Type", "application/json");

--- a/src/containers/EnhetensMoterContainer.tsx
+++ b/src/containers/EnhetensMoterContainer.tsx
@@ -11,16 +11,19 @@ import { useOverforMoter } from "../hooks/useOverforMoter";
 import { useMoterEnhet } from "../hooks/useMoterEnhet";
 import EnhetensMoter from "../components/EnhetensMoter";
 import { resetOverforing } from "../data/moter/overfor_actions";
+import { useAktivEnhet } from "../data/enhet/enhet_hooks";
+import { useDialogmoter } from "../data/dialogmoter/dialogmoter_hooks";
 
 const EnhetensMoterContainer = (): ReactElement => {
   const { harOvertattMoter } = useOverforMoter();
   const {
-    aktivEnhet,
     henterMoter,
     hentMoterFeilet,
     moter,
-    hentetEnhet,
+    hentetMoterForEnhet,
   } = useMoterEnhet();
+  const { hentetDialogmoterForEnhet } = useDialogmoter();
+  const aktivEnhet = useAktivEnhet();
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -30,11 +33,16 @@ const EnhetensMoterContainer = (): ReactElement => {
   }, [harOvertattMoter]);
 
   useEffect(() => {
-    if (aktivEnhet !== hentetEnhet) {
+    if (aktivEnhet !== hentetMoterForEnhet) {
       dispatch(hentEnhetsMoter(aktivEnhet));
+    }
+  }, [aktivEnhet, hentetMoterForEnhet]);
+
+  useEffect(() => {
+    if (aktivEnhet !== hentetDialogmoterForEnhet) {
       dispatch(hentDialogmoter(aktivEnhet));
     }
-  }, [aktivEnhet, hentetEnhet]);
+  }, [aktivEnhet, hentetDialogmoterForEnhet]);
 
   return (
     <Side tittel="Møteoversikt">

--- a/src/containers/MineMoterContainer.tsx
+++ b/src/containers/MineMoterContainer.tsx
@@ -8,9 +8,14 @@ import NavigasjonsTopp from "../components/NavigasjonsTopp";
 import { useMoter } from "../hooks/useMoter";
 import { hentMoter } from "../data/moter/moter_actions";
 import { useDispatch } from "react-redux";
+import { useAktivEnhet } from "../data/enhet/enhet_hooks";
+import { hentDialogmoter } from "../data/dialogmoter/dialogmoter_actions";
+import { useDialogmoter } from "../data/dialogmoter/dialogmoter_hooks";
 
 const MineMoterContainer = (): ReactElement => {
   const { moter, henterMoter, hentMoterFeilet } = useMoter();
+  const { hentetDialogmoterForEnhet } = useDialogmoter();
+  const aktivEnhet = useAktivEnhet();
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -18,6 +23,12 @@ const MineMoterContainer = (): ReactElement => {
       dispatch(hentMoter());
     }
   }, []);
+
+  useEffect(() => {
+    if (aktivEnhet !== hentetDialogmoterForEnhet) {
+      dispatch(hentDialogmoter(aktivEnhet));
+    }
+  }, [aktivEnhet, hentetDialogmoterForEnhet]);
 
   return (
     <Side tittel="Møteoversikt">

--- a/src/data/dialogmoter/dialogmoter.ts
+++ b/src/data/dialogmoter/dialogmoter.ts
@@ -6,6 +6,13 @@ import {
 } from "./dialogmoter_actions";
 import { Reducer } from "redux";
 
+export enum DialogmoteStatus {
+  INNKALT = "INNKALT",
+  AVLYST = "AVLYST",
+  FERDIGSTILT = "FERDIGSTILT",
+  NYTT_TID_STED = "NYTT_TID_STED",
+}
+
 interface DialogmotedeltakerArbeidstakerVarselDTO {
   uuid: string;
   createdAt: string;
@@ -30,33 +37,25 @@ interface DialogmotedeltakerArbeidsgiverDTO {
   type: string;
 }
 
-interface DialogmoteTidStedDTO {
-  uuid: string;
-  sted: string;
-  tid: string;
-}
-
 export interface DialogmoterDTO {
   uuid: string;
   createdAt: string;
   updatedAt: string;
-  planlagtMoteUuid: string | null;
-  planlagtMoteBekreftetTidspunkt: string | null;
-  status: string;
+  status: DialogmoteStatus;
   opprettetAv: string;
   tildeltVeilederIdent: string;
   tildeltEnhet: string;
   arbeidstaker: DialogmotedeltakerArbeidstakerDTO;
   arbeidsgiver: DialogmotedeltakerArbeidsgiverDTO;
-  tidStedList: DialogmoteTidStedDTO[];
+  sted: string;
+  tid: string;
 }
 
 export interface DialogmoterState {
   henter: boolean;
   hentingFeilet: boolean;
   hentet: boolean;
-  hentingForsokt: boolean;
-
+  hentetEnhet: string;
   data: DialogmoterDTO[];
 }
 
@@ -64,8 +63,7 @@ export const initialState: DialogmoterState = {
   henter: false,
   hentingFeilet: false,
   hentet: false,
-  hentingForsokt: false,
-
+  hentetEnhet: "",
   data: [],
 };
 
@@ -80,7 +78,6 @@ const dialogmoter: Reducer<DialogmoterState, DialogmoterActions> = (
         henter: true,
         hentingFeilet: false,
         hentet: false,
-        hentingForsokt: true,
       };
     }
     case HENT_DIALOGMOTER_HENTET: {
@@ -90,7 +87,7 @@ const dialogmoter: Reducer<DialogmoterState, DialogmoterActions> = (
         hentingFeilet: false,
         hentet: true,
         data: action.data,
-        hentingForsokt: true,
+        hentetEnhet: action.enhet,
       };
     }
     case HENT_DIALOGMOTER_FEILET: {
@@ -99,7 +96,6 @@ const dialogmoter: Reducer<DialogmoterState, DialogmoterActions> = (
         henter: false,
         hentingFeilet: true,
         hentet: false,
-        hentingForsokt: true,
       };
     }
     default:

--- a/src/data/dialogmoter/dialogmoterSagas.ts
+++ b/src/data/dialogmoter/dialogmoterSagas.ts
@@ -1,6 +1,6 @@
-import { all, call, put, select, takeEvery } from "redux-saga/effects";
+import { call, put, takeEvery } from "redux-saga/effects";
 import { get } from "../../api";
-import { DialogmoterState } from "./dialogmoter";
+import { DialogmoterDTO } from "./dialogmoter";
 import {
   HentDialogmoterAction,
   hentDialogmoterFeilet,
@@ -14,34 +14,13 @@ export function* hentDialogmoter(action: HentDialogmoterAction) {
   yield put(hentDialogmoterHenter());
   try {
     const path = `${ISDIALOGMOTE_ROOT}/v2/dialogmote/enhet/${action.enhetNr}`;
-    const data = yield call(get, path);
-
-    if (data && !!data.err) {
-      yield put(hentDialogmoterFeilet());
-    } else {
-      yield put(hentDialogmoterHentet(data || {}, action.enhetNr));
-    }
+    const data: DialogmoterDTO[] = yield call(get, path);
+    yield put(hentDialogmoterHentet(data || {}, action.enhetNr));
   } catch (e) {
     yield put(hentDialogmoterFeilet());
   }
 }
 
-export const skalHenteDialogmoter = (state: {
-  dialogmoter: DialogmoterState;
-}) => {
-  const reducer = state.dialogmoter;
-  return !reducer.hentingForsokt;
-};
-
-export function* hentDialogmoterHvisIkkeHentet(action: HentDialogmoterAction) {
-  const skalHente = yield select(skalHenteDialogmoter);
-  if (skalHente) {
-    yield hentDialogmoter(action);
-  }
-}
-
 export default function* dialogmoterSagas() {
-  yield all([
-    takeEvery(HENT_DIALOGMOTER_FORESPURT, hentDialogmoterHvisIkkeHentet),
-  ]);
+  yield takeEvery(HENT_DIALOGMOTER_FORESPURT, hentDialogmoter);
 }

--- a/src/data/dialogmoter/dialogmoter_hooks.ts
+++ b/src/data/dialogmoter/dialogmoter_hooks.ts
@@ -1,0 +1,29 @@
+import { useAppSelector } from "../../hooks/hooks";
+import { DialogmoteStatus } from "./dialogmoter";
+import { useAktivVeileder } from "../veiledere/veileder_hooks";
+
+export const useDialogmoter = () => {
+  const { data, hentingFeilet, henter, hentetEnhet } = useAppSelector(
+    (state) => state.dialogmoter
+  );
+  const aktiveDialogmoter = data.filter(
+    (dialogmote) =>
+      dialogmote.status === DialogmoteStatus.INNKALT ||
+      dialogmote.status === DialogmoteStatus.NYTT_TID_STED
+  );
+  const aktivVeileder = useAktivVeileder();
+  const mineAktiveDialogmoter = aktiveDialogmoter.filter(
+    (dialogmote) => dialogmote.tildeltVeilederIdent === aktivVeileder
+  );
+
+  return {
+    dialogmoter: data,
+    aktiveDialogmoter,
+    mineAktiveDialogmoter,
+    harMineAktiveDialogmoter: mineAktiveDialogmoter.length > 0,
+    harAktiveDialogmoter: aktiveDialogmoter.length > 0,
+    henterDialogmoter: henter,
+    hentDialogmoterFeilet: hentingFeilet,
+    hentetDialogmoterForEnhet: hentetEnhet,
+  };
+};

--- a/src/data/enhet/enhet.ts
+++ b/src/data/enhet/enhet.ts
@@ -1,0 +1,29 @@
+import { Reducer } from "redux";
+import { EnhetActions, SET_AKTIV_ENHET } from "./enhet_actions";
+
+interface EnhetState {
+  aktivEnhet: string;
+}
+
+const defaultState: EnhetState = {
+  aktivEnhet: "",
+};
+
+const enhet: Reducer<EnhetState, EnhetActions> = (
+  state = defaultState,
+  action
+) => {
+  switch (action.type) {
+    case SET_AKTIV_ENHET: {
+      return {
+        ...state,
+        aktivEnhet: action.enhet,
+      };
+    }
+    default: {
+      return state;
+    }
+  }
+};
+
+export default enhet;

--- a/src/data/enhet/enhet_actions.ts
+++ b/src/data/enhet/enhet_actions.ts
@@ -1,0 +1,13 @@
+export const SET_AKTIV_ENHET = "SET_AKTIV_ENHET";
+
+export interface SetAktivEnhetAction {
+  type: typeof SET_AKTIV_ENHET;
+  enhet: string;
+}
+
+export type EnhetActions = SetAktivEnhetAction;
+
+export const setAktivEnhet = (enhet: string): SetAktivEnhetAction => ({
+  type: SET_AKTIV_ENHET,
+  enhet,
+});

--- a/src/data/enhet/enhet_hooks.ts
+++ b/src/data/enhet/enhet_hooks.ts
@@ -1,0 +1,6 @@
+import { useAppSelector } from "../../hooks/hooks";
+
+export const useAktivEnhet = (): string => {
+  const { aktivEnhet } = useAppSelector((state) => state.enhet);
+  return aktivEnhet;
+};

--- a/src/data/moter/moterEnhet.ts
+++ b/src/data/moter/moterEnhet.ts
@@ -10,7 +10,6 @@ import {
   HENT_ENHETSMOTER_FEILET,
   HENTER_ENHETSMOTER,
   MoterEnhetActions,
-  SET_AKTIV_ENHET,
 } from "./moterEnhet_actions";
 import { FNR_HENTET, FnrActions } from "../fnr/fnr_actions";
 import {
@@ -24,7 +23,6 @@ import { getDeltagereMedFnr, getDeltagereMedNavn } from "../../utils/moterUtil";
 interface MoterEnhetState {
   henter: boolean;
   hentingFeilet: boolean;
-  aktivEnhet: string;
   hentetEnhet: string;
   data: MoteDTO[];
 }
@@ -33,7 +31,6 @@ const defaultState: MoterEnhetState = {
   data: [],
   henter: false,
   hentingFeilet: false,
-  aktivEnhet: "",
   hentetEnhet: "",
 };
 
@@ -55,12 +52,6 @@ const moterEnhet: Reducer<MoterEnhetState, MoterEnhetReducerAction> = (
         henter: true,
         hentingFeilet: false,
         hentetEnhet: action.enhet,
-      };
-    }
-    case SET_AKTIV_ENHET: {
-      return {
-        ...state,
-        aktivEnhet: action.enhet,
       };
     }
     case ENHETSMOTER_HENTET: {

--- a/src/data/moter/moterEnhet_actions.ts
+++ b/src/data/moter/moterEnhet_actions.ts
@@ -1,18 +1,12 @@
 import { MoteDTO } from "./moterTypes";
 
 export const HENT_ENHETSMOTER = "HENT_ENHETSMOTER";
-export const SET_AKTIV_ENHET = "SET_AKTIV_ENHET";
 export const HENTER_ENHETSMOTER = "HENTER_ENHETSMOTER";
 export const HENT_ENHETSMOTER_FEILET = "HENT_ENHETSMOTER_FEILET";
 export const ENHETSMOTER_HENTET = "ENHETSMOTER_HENTET";
 
 export interface HentEnhetsMoterAction {
   type: typeof HENT_ENHETSMOTER;
-  enhet: string;
-}
-
-export interface SetAktivEnhetAction {
-  type: typeof SET_AKTIV_ENHET;
   enhet: string;
 }
 
@@ -32,18 +26,12 @@ export interface HentEnhetsMoterFeiletAction {
 
 export type MoterEnhetActions =
   | HentEnhetsMoterAction
-  | SetAktivEnhetAction
   | HenterEnhetsMoterAction
   | EnhetsMoterHentetAction
   | HentEnhetsMoterFeiletAction;
 
 export const hentEnhetsMoter = (enhet: string): HentEnhetsMoterAction => ({
   type: HENT_ENHETSMOTER,
-  enhet,
-});
-
-export const setAktivEnhet = (enhet: string): SetAktivEnhetAction => ({
-  type: SET_AKTIV_ENHET,
   enhet,
 });
 

--- a/src/data/veiledere/veilederSagas.ts
+++ b/src/data/veiledere/veilederSagas.ts
@@ -16,6 +16,9 @@ export function* hentVeileder(action: HenterVeilederAction) {
       `${SYFOVEILEDER_ROOT}/v2/veileder${optionalPathParameter}`
     );
     yield put(actions.veilederHentet(data));
+    if (!action.data.ident) {
+      yield put(actions.setAktivVeileder(data.ident || ""));
+    }
   } catch (e) {
     yield put(actions.hentVeilederFeilet(action.data));
   }

--- a/src/data/veiledere/veileder_actions.ts
+++ b/src/data/veiledere/veileder_actions.ts
@@ -4,6 +4,7 @@ export const HENT_VEILEDER = "HENT_VEILEDER_FORESPURT";
 export const HENTER_VEILEDER = "HENTER_VEILEDER";
 export const VEILEDER_HENTET = "VEILEDER_HENTET";
 export const HENT_VEILEDER_FEILET = "HENT_VEILEDER_FEILET";
+export const SET_AKTIV_VEILEDER = "SET_AKTIV_VEILEDER";
 
 export interface HentVeilederAction {
   type: typeof HENT_VEILEDER;
@@ -20,6 +21,11 @@ export interface VeilederHentetAction {
   data: VeilederDto;
 }
 
+export interface SetAktivVeilederAction {
+  type: typeof SET_AKTIV_VEILEDER;
+  veileder: string;
+}
+
 export interface HentVeilederFeiletAction {
   type: typeof HENT_VEILEDER_FEILET;
   data: VeilederDto;
@@ -29,7 +35,8 @@ export type VeilederActions =
   | HentVeilederAction
   | HenterVeilederAction
   | VeilederHentetAction
-  | HentVeilederFeiletAction;
+  | HentVeilederFeiletAction
+  | SetAktivVeilederAction;
 
 export const hentVeileder = (data: VeilederDto): HentVeilederAction => ({
   type: HENT_VEILEDER,
@@ -44,6 +51,11 @@ export const henterVeileder = (data: VeilederDto): HenterVeilederAction => ({
 export const veilederHentet = (data: VeilederDto): VeilederHentetAction => ({
   type: VEILEDER_HENTET,
   data,
+});
+
+export const setAktivVeileder = (veileder: string): SetAktivVeilederAction => ({
+  type: SET_AKTIV_VEILEDER,
+  veileder,
 });
 
 export const hentVeilederFeilet = (

--- a/src/data/veiledere/veileder_hooks.ts
+++ b/src/data/veiledere/veileder_hooks.ts
@@ -1,0 +1,4 @@
+import { useAppSelector } from "../../hooks/hooks";
+
+export const useAktivVeileder = (): string =>
+  useAppSelector((state) => state.veiledere.aktivVeileder);

--- a/src/data/veiledere/veiledere.ts
+++ b/src/data/veiledere/veiledere.ts
@@ -3,16 +3,19 @@ import { Reducer } from "redux";
 import {
   HENT_VEILEDER_FEILET,
   HENTER_VEILEDER,
+  SET_AKTIV_VEILEDER,
   VEILEDER_HENTET,
   VeilederActions,
 } from "./veileder_actions";
 
 interface VeiledereState {
   data: VeilederDto[];
+  aktivVeileder: string;
 }
 
 const defaultState: VeiledereState = {
   data: [],
+  aktivVeileder: "",
 };
 
 const veiledere: Reducer<VeiledereState, VeilederActions> = (
@@ -71,6 +74,12 @@ const veiledere: Reducer<VeiledereState, VeilederActions> = (
       return {
         ...state,
         data,
+      };
+    }
+    case SET_AKTIV_VEILEDER: {
+      return {
+        ...state,
+        aktivVeileder: action.veileder,
       };
     }
     default: {

--- a/src/decorator/Decorator.tsx
+++ b/src/decorator/Decorator.tsx
@@ -4,7 +4,7 @@ import NAVSPA from "@navikt/navspa";
 import { DecoratorProps } from "./decoratorProps";
 import decoratorConfig from "./decoratorConfig";
 import { fullNaisUrlDefault } from "../utils/miljoUtil";
-import { setAktivEnhet } from "../data/moter/moterEnhet_actions";
+import { setAktivEnhet } from "../data/enhet/enhet_actions";
 
 const InternflateDecorator = NAVSPA.importer<DecoratorProps>(
   "internarbeidsflatefs"

--- a/src/hooks/useMoterEnhet.ts
+++ b/src/hooks/useMoterEnhet.ts
@@ -9,18 +9,16 @@ interface MoteMedVeileder extends MoteDTO {
 }
 
 export const useMoterEnhet: () => {
-  hentetEnhet: string;
   getStatuser: () => string[];
   getVeiledere: () => string[];
-  aktivEnhet: string;
   hentMoterFeilet: boolean;
   moter: MoteDTO[];
   aktiveMoterMedStatusOgVeileder: MoteMedVeileder[];
   harAktiveMoter: boolean;
   henterMoter: boolean;
+  hentetMoterForEnhet: string;
 } = () => {
   const {
-    aktivEnhet,
     hentetEnhet,
     hentingFeilet: hentMoterFeilet,
     henter: henterMoter,
@@ -36,8 +34,7 @@ export const useMoterEnhet: () => {
   );
 
   return {
-    aktivEnhet,
-    hentetEnhet,
+    hentetMoterForEnhet: hentetEnhet,
     moter,
     harAktiveMoter: aktiveMoterMedStatus.length > 0,
     aktiveMoterMedStatusOgVeileder,

--- a/src/index.js
+++ b/src/index.js
@@ -13,13 +13,16 @@ import moterEnhet from "./data/moter/moterEnhet";
 import veiledere from "./data/veiledere/veiledere";
 import overfor from "./data/moter/overfor";
 import dialogmoter from "./data/dialogmoter/dialogmoter";
+import enhet from "./data/enhet/enhet";
 import rootSaga from "./sagas/index";
 import { hentMoter } from "./data/moter/moter_actions";
+import { hentVeileder } from "./data/veiledere/veileder_actions";
 
 const history = createBrowserHistory();
 
 const rootReducer = combineReducers({
   router: connectRouter(history),
+  enhet,
   moter,
   overfor,
   veiledere,
@@ -37,6 +40,7 @@ const store = createStore(
 sagaMiddleware.run(rootSaga);
 
 store.dispatch(hentMoter());
+store.dispatch(hentVeileder({}));
 
 render(
   <Provider store={store}>


### PR DESCRIPTION
- Henter dialogmoter for enhet i enhetens moter og mine moter
- Flyttet aktiv enhet til egen reducer og setter aktiv veileder i redux
- Oppdatert dialogmøte typer og mockdata.
- Laget useDialogmoter til bruk i visningskomponentene i videre PRer.