### PR TITLE
Simplify debugging of components using Styled-components

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,6 @@
 {
   "presets": [
+    "babel-plugin-styled-components",
     "@babel/preset-env",
     "@babel/preset-react",
     "@babel/preset-typescript"

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,7 @@
         "autoprefixer": "10.4.4",
         "babel-loader": "8.2.3",
         "babel-plugin-module-resolver": "4.1.0",
+        "babel-plugin-styled-components": "^2.0.7",
         "chai": "4.3.6",
         "clean-webpack-plugin": "4.0.0",
         "css-loader": "6.7.1",
@@ -3739,14 +3740,15 @@
       }
     },
     "node_modules/babel-plugin-styled-components": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.2.tgz",
-      "integrity": "sha512-7eG5NE8rChnNTDxa6LQfynwgHTVOYYaHJbUYSlOhk8QBXIQiMBKq4gyfHBBKPrxUcVBXVJL61ihduCpCQbuNbw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
+      "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.16.0",
         "@babel/helper-module-imports": "^7.16.0",
         "babel-plugin-syntax-jsx": "^6.18.0",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.11",
+        "picomatch": "^2.3.0"
       },
       "peerDependencies": {
         "styled-components": ">= 2"
@@ -9843,7 +9845,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
       "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
-      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -15552,14 +15553,15 @@
       }
     },
     "babel-plugin-styled-components": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.2.tgz",
-      "integrity": "sha512-7eG5NE8rChnNTDxa6LQfynwgHTVOYYaHJbUYSlOhk8QBXIQiMBKq4gyfHBBKPrxUcVBXVJL61ihduCpCQbuNbw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
+      "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.16.0",
         "@babel/helper-module-imports": "^7.16.0",
         "babel-plugin-syntax-jsx": "^6.18.0",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.11",
+        "picomatch": "^2.3.0"
       }
     },
     "babel-plugin-syntax-jsx": {
@@ -20137,8 +20139,7 @@
     "picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
-      "dev": true
+      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
     },
     "pify": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "autoprefixer": "10.4.4",
     "babel-loader": "8.2.3",
     "babel-plugin-module-resolver": "4.1.0",
+    "babel-plugin-styled-components": "2.0.7",
     "chai": "4.3.6",
     "clean-webpack-plugin": "4.0.0",
     "css-loader": "6.7.1",


### PR DESCRIPTION
Add babel-plugin-styled-components to make is easier to debug html elements and css rendered from componennts using styled-components. This package adds automatic annoations of styled components with a unique and readable html class name.