### PR TITLE
IS-2032: Refactored MineMoter and EnhetensMoter into /sider folder

### DIFF
--- a/src/components/layout/SideFullbredde.tsx
+++ b/src/components/layout/SideFullbredde.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useEffect } from "react";
 import DocumentTitle from "react-document-title";
-import Decorator from "../decorator/Decorator";
+import Decorator from "../../decorator/Decorator";
 import { trackPageLoad } from "@/amplitude/amplitude";
 import { useAktivEnhet } from "@/context/aktivEnhet/AktivEnhetContext";
 import { Column, Container, Row } from "@/components/layout/Layout";

--- a/src/routers/AppRouter.tsx
+++ b/src/routers/AppRouter.tsx
@@ -5,8 +5,8 @@ import {
   Route,
   Routes,
 } from "react-router-dom";
-import MineMoterContainer from "../containers/MineMoterContainer";
-import EnhetensMoterContainer from "../containers/EnhetensMoterContainer";
+import MineMoterContainer from "../sider/minemoter/MineMoterContainer";
+import EnhetensMoterContainer from "../sider/enhetensmoter/EnhetensMoterContainer";
 
 export const mineMoterRoutePath = "/syfomoteoversikt/minemoter";
 export const enhetMoterOversiktRoutePath = "/syfomoteoversikt/enhetensmoter";

--- a/src/sider/enhetensmoter/EnhetensMoter.tsx
+++ b/src/sider/enhetensmoter/EnhetensMoter.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from "react";
-import MoteoversiktEnhet from "./MoteoversiktEnhet";
+import MoteoversiktEnhet from "../../components/MoteoversiktEnhet";
 import { useOverforDialogmoter } from "@/data/dialogmoter/useOverforDialogmoter";
 import { useEnhetensDialogmoterQuery } from "@/data/dialogmoter/dialogmoterQueryHooks";
 import { Alert } from "@navikt/ds-react";

--- a/src/sider/enhetensmoter/EnhetensMoterContainer.tsx
+++ b/src/sider/enhetensmoter/EnhetensMoterContainer.tsx
@@ -1,8 +1,8 @@
 import React, { ReactElement, useEffect } from "react";
-import SideFullBredde from "@/sider/SideFullbredde";
-import Feilmelding from "../components/Feilmelding";
-import NavigasjonsTopp from "../components/NavigasjonsTopp";
-import EnhetensMoter from "../components/EnhetensMoter";
+import SideFullBredde from "@/components/layout/SideFullbredde";
+import Feilmelding from "../../components/Feilmelding";
+import NavigasjonsTopp from "../../components/NavigasjonsTopp";
+import EnhetensMoter from "./EnhetensMoter";
 
 import { useAktivEnhet } from "@/context/aktivEnhet/AktivEnhetContext";
 import { useEnhetensDialogmoterQuery } from "@/data/dialogmoter/dialogmoterQueryHooks";

--- a/src/sider/minemoter/MineMoter.tsx
+++ b/src/sider/minemoter/MineMoter.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from "react";
 import { Label, Panel } from "@navikt/ds-react";
-import Moteoversikt from "./Moteoversikt";
+import Moteoversikt from "../../components/Moteoversikt";
 import { dagensDatoKortFormat } from "@/utils/dateUtil";
 import { useAktivVeileder } from "@/data/veiledere/veilederQueryHooks";
 import { useMineDialogmoterQuery } from "@/data/dialogmoter/dialogmoterQueryHooks";

--- a/src/sider/minemoter/MineMoterContainer.tsx
+++ b/src/sider/minemoter/MineMoterContainer.tsx
@@ -1,8 +1,8 @@
 import React, { ReactElement } from "react";
-import SideFullBredde from "@/sider/SideFullbredde";
-import Feilmelding from "../components/Feilmelding";
-import Moter from "../components/MineMoter";
-import NavigasjonsTopp from "../components/NavigasjonsTopp";
+import SideFullBredde from "@/components/layout/SideFullbredde";
+import Feilmelding from "../../components/Feilmelding";
+import Moter from "./MineMoter";
+import NavigasjonsTopp from "../../components/NavigasjonsTopp";
 import { useMineDialogmoterQuery } from "@/data/dialogmoter/dialogmoterQueryHooks";
 import {
   enhetMoterOversiktRoutePath,

--- a/test/components/EnhetensMoterTest.tsx
+++ b/test/components/EnhetensMoterTest.tsx
@@ -1,4 +1,4 @@
-import EnhetensMoter from "../../src/components/EnhetensMoter";
+import EnhetensMoter from "@/sider/enhetensmoter/EnhetensMoter";
 import React from "react";
 import {
   DialogmoteStatus,

--- a/test/components/MineMoterTest.tsx
+++ b/test/components/MineMoterTest.tsx
@@ -5,7 +5,7 @@ import {
   daysFromToday,
 } from "../testUtil";
 import React from "react";
-import MineMoter from "../../src/components/MineMoter";
+import MineMoter from "@/sider/minemoter/MineMoter";
 import {
   DialogmoteStatus,
   SvarType,


### PR DESCRIPTION
Flyttet `MineMoter` og `EnhetensMoter` filer inn i `/sider` mappe slik at mappestrukturen gjenspeiler hvordan navigasjonen er.