### PR TITLE
IS-2059: Show loading until data is fetched

### DIFF
--- a/src/components/MineMoter.tsx
+++ b/src/components/MineMoter.tsx
@@ -2,10 +2,10 @@ import React, { ReactElement } from "react";
 import { Label, Panel } from "@navikt/ds-react";
 import Moteoversikt from "./Moteoversikt";
 import { dagensDatoKortFormat } from "@/utils/dateUtil";
-import { useAktivVeileder } from "@/data/veiledere/veilederQueryHooks";
-import { useMineDialogmoterQuery } from "@/data/dialogmoter/dialogmoterQueryHooks";
 import { useMoteoverforing } from "@/context/moteoverforing/MoteoverforingContext";
 import { Alert } from "@navikt/ds-react";
+import { DialogmoterDTO } from "@/data/dialogmoter/dialogmoterTypes";
+import { VeilederInfoDto } from "@/data/veiledere/veilederTypes";
 
 const tallOrdFraTall = (tall: number): string | number => {
   switch (tall) {
@@ -63,12 +63,15 @@ const texts = {
   ingenMoter: "Du har ingen aktive møter.",
 };
 
-const Moter = (): ReactElement => {
-  const aktivVeilederIdent = useAktivVeileder().data?.ident;
+interface Props {
+  aktivVeileder: VeilederInfoDto;
+  moter: DialogmoterDTO[];
+}
+
+const Moter = ({ aktivVeileder, moter }: Props): ReactElement => {
   const { antallOverfort } = useMoteoverforing();
-  const dialogmoterQuery = useMineDialogmoterQuery();
-  const harMoter = dialogmoterQuery.data?.some(
-    ({ tildeltVeilederIdent }) => tildeltVeilederIdent === aktivVeilederIdent
+  const harMoter = moter.some(
+    ({ tildeltVeilederIdent }) => tildeltVeilederIdent === aktivVeileder.ident
   );
 
   return (

--- a/src/containers/MineMoterContainer.tsx
+++ b/src/containers/MineMoterContainer.tsx
@@ -9,16 +9,16 @@ import {
   mineMoterRoutePath,
 } from "@/routers/AppRouter";
 import { Loader } from "@navikt/ds-react";
-import { Column, RowCentered } from "@/components/layout/Layout";
-
-const texts = {
-  ingenMoter: "Bruker har ingen møter",
-};
+import { Column } from "@/components/layout/Layout";
+import { useAktivVeileder } from "@/data/veiledere/veilederQueryHooks";
 
 const MineMoterContainer = (): ReactElement => {
+  const aktivVeilederQuery = useAktivVeileder();
   const dialogmoterQuery = useMineDialogmoterQuery();
-  const harMoter =
-    dialogmoterQuery.isSuccess && dialogmoterQuery.data.length > 0;
+
+  const isLoading = aktivVeilederQuery.isLoading || dialogmoterQuery.isLoading;
+  const isError = aktivVeilederQuery.isError || dialogmoterQuery.isError;
+  const isSuccess = aktivVeilederQuery.isSuccess && dialogmoterQuery.isSuccess;
 
   return (
     <SideFullBredde tittel="Møteoversikt">
@@ -37,20 +37,14 @@ const MineMoterContainer = (): ReactElement => {
             },
           ]}
         />
-        {(() => {
-          if (dialogmoterQuery.isLoading) {
-            return (
-              <RowCentered>
-                <Loader size="2xlarge" />
-              </RowCentered>
-            );
-          } else if (dialogmoterQuery.isError) {
-            return <Feilmelding />;
-          } else if (harMoter) {
-            return <Moter />;
-          }
-          return <p>{texts.ingenMoter}</p>;
-        })()}
+        {isLoading && <Loader size="2xlarge" className="flex justify-center" />}
+        {isError && <Feilmelding />}
+        {isSuccess && (
+          <Moter
+            aktivVeileder={aktivVeilederQuery.data}
+            moter={dialogmoterQuery.data}
+          />
+        )}
       </Column>
     </SideFullBredde>
   );

--- a/test/components/MineMoterTest.tsx
+++ b/test/components/MineMoterTest.tsx
@@ -86,7 +86,7 @@ describe("MineMoter", () => {
             setAktivEnhet: () => void 0,
           }}
         >
-          <MineMoter />
+          <MineMoter aktivVeileder={veilederMock} moter={dialogmoterData} />
         </AktivEnhetContext.Provider>
       </QueryClientProvider>
     );
@@ -109,7 +109,7 @@ describe("MineMoter", () => {
             setAktivEnhet: () => void 0,
           }}
         >
-          <MineMoter />
+          <MineMoter aktivVeileder={veilederMock} moter={dialogmoterData} />
         </AktivEnhetContext.Provider>
       </QueryClientProvider>
     );


### PR DESCRIPTION
- Fikser at det vises "ingen møter" før data er ferdig hentet. Problemet var at selv om møtene var hentet så hadde `MineMoter` komponenten en hook som hentet aktiv veileder. Det viste da "ingen møter" til denne var ferdig hentet.
- Endrer også slik at vi sender inn aktiv veileder og møtene. Synes det ser ryddig ut når komponenten får inn det den trenger for å rendres riktig der det er naturlig. Så slipper vi å ha loading state utenfor og innenfor selve komponenten. Tar gjerne innspill på dette 😊