### PR TITLE
IS-2064: Refetch meetings after overtakelse

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,6 @@
         "react": "18.2.0",
         "react-document-title": "2.0.3",
         "react-dom": "18.2.0",
-        "react-hook-form": "7.50.0",
         "react-router-dom": "6.6.2",
         "redis": "3.1.2",
         "styled-components": "5.3.6"
@@ -10945,21 +10944,6 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
-      }
-    },
-    "node_modules/react-hook-form": {
-      "version": "7.50.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.50.0.tgz",
-      "integrity": "sha512-AOhuzM3RdP09ZCnq+Z0yvKGHK25yiOX5phwxjV9L7U6HMla10ezkBnvQ+Pk4GTuDfsC5P2zza3k8mawFwFLVuQ==",
-      "engines": {
-        "node": ">=12.22.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/react-hook-form"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17 || ^18"
       }
     },
     "node_modules/react-is": {

--- a/src/data/dialogmoter/useOverforDialogmoter.ts
+++ b/src/data/dialogmoter/useOverforDialogmoter.ts
@@ -15,6 +15,7 @@ export const useOverforDialogmoter = () => {
   const queryClient = useQueryClient();
   const path = `${ISDIALOGMOTE_ROOT}/v2/dialogmote/overta`;
   const dialogmoterQueryKey = dialogmoterQueryKeys.dialogmoter(aktivEnhet);
+  const dialogmoterVeilederidentQueryKey = dialogmoterQueryKeys.veilederident;
   const postOverforDialogmoter = (dialogmoteUuids: string[]) =>
     post(path, { dialogmoteUuids });
 
@@ -51,7 +52,11 @@ export const useOverforDialogmoter = () => {
     },
     onSuccess: () =>
       dispatch({ type: MoteoverforingActionType.DialogmoterOverfort }),
-    onSettled: () =>
-      queryClient.invalidateQueries({ queryKey: dialogmoterQueryKey }),
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: dialogmoterQueryKey });
+      queryClient.invalidateQueries({
+        queryKey: dialogmoterVeilederidentQueryKey,
+      });
+    },
   });
 };


### PR DESCRIPTION
Hvis man overtar møter fra enhetens oversikt, står det at man ikke har noen møter når man kommer inn på min oversikt.
Nå henter vi mine møter på nytt uten at veileder trenger å oppdatere siden.