### PR TITLE
IS-2518: Add respons from behandler when innkalt

### DIFF
--- a/mock/Data/dialogmoterMock.ts
+++ b/mock/Data/dialogmoterMock.ts
@@ -174,6 +174,22 @@ const dialogmoter = [
       svar: { svarType: SvarType.KOMMER_IKKE },
     }
   ),
+  createDialogmote(
+    "11",
+    addDaysToToday(19),
+    DialogmoteStatus.INNKALT,
+    DialogmoteDeltakerVarselType.INNKALT,
+    "Z990197",
+    {
+      lestDato: addDaysToToday(-1).toISOString(),
+      svar: { svarType: SvarType.NYTT_TID_STED },
+    },
+    {
+      lestDato: addDaysToToday(-1).toISOString(),
+      svar: { svarType: SvarType.KOMMER_IKKE },
+    },
+    { varselType: DialogmoteDeltakerVarselType.INNKALT, svar: [] }
+  ),
 ];
 
 export const dialogmoterMock = dialogmoter;

--- a/src/components/MoteresponsColumn.tsx
+++ b/src/components/MoteresponsColumn.tsx
@@ -9,7 +9,13 @@ import {
   getBehandlerRespons,
 } from "@/utils/dialogmoterUtil";
 
-function ResponsTag({ respons }: { respons: DeltakerRespons }): ReactElement {
+function ResponsTag({
+  respons,
+  deltaker,
+}: {
+  respons: DeltakerRespons;
+  deltaker: string;
+}): ReactElement {
   if (respons.svar === SvarType.KOMMER) {
     return (
       <Tag variant="success" size="xsmall">
@@ -34,6 +40,12 @@ function ResponsTag({ respons }: { respons: DeltakerRespons }): ReactElement {
         Har åpnet
       </Tag>
     );
+  } else if (deltaker === "Behandler" && !respons.harLest && !respons.svar) {
+    return (
+      <Tag variant="alt2" size="xsmall">
+        Ikke svart
+      </Tag>
+    );
   } else {
     return (
       <Tag variant="alt2" size="xsmall">
@@ -55,7 +67,7 @@ function ResponseEntry({
       <BodyShort size="small" className="w-24">
         {deltaker}:
       </BodyShort>
-      <ResponsTag respons={respons} />
+      <ResponsTag respons={respons} deltaker={deltaker} />
     </div>
   );
 }
@@ -73,10 +85,13 @@ export default function MoteresponsColumn({ dialogmote }: Props): ReactElement {
     <ResponsColumn>
       <ResponseEntry deltaker={"Arbeidstaker"} respons={arbeidstakerRespons} />
       <ResponseEntry deltaker={"Arbeidsgiver"} respons={arbeidsgiverRespons} />
-      {behandlerSvar && (
+      {dialogmote.behandler && (
         <ResponseEntry
           deltaker={"Behandler"}
-          respons={{ harLest: false, svar: behandlerSvar }}
+          respons={{
+            harLest: false,
+            svar: behandlerSvar ? behandlerSvar : undefined,
+          }}
         />
       )}
     </ResponsColumn>

--- a/src/utils/dialogmoterUtil.ts
+++ b/src/utils/dialogmoterUtil.ts
@@ -7,7 +7,7 @@ import {
   SvarType,
 } from "@/data/dialogmoter/dialogmoterTypes";
 
-export type DeltakerRespons = { harLest: boolean; svar?: SvarType };
+export type DeltakerRespons = { harLest: boolean; svar: SvarType | undefined };
 
 export const erResponsMottatt = (dialogmote: DialogmoterDTO): boolean => {
   const { svar: arbeidstakerSvar } = getArbeidstakerRespons(dialogmote);
@@ -69,15 +69,10 @@ const getDeltakerRespons = (
     (varsel) => varsel.varselType === varselTypeFromStatus(status)
   );
 
-  const respons: DeltakerRespons = {
+  return {
     harLest: !!latestVarsel?.lestDato,
+    svar: latestVarsel?.svar?.svarType ? latestVarsel.svar.svarType : undefined,
   };
-
-  if (latestVarsel?.svar?.svarType) {
-    respons.svar = latestVarsel.svar.svarType;
-  }
-
-  return respons;
 };
 
 const varselTypeFromStatus = (

--- a/test/components/MoteresponsColumnTest.tsx
+++ b/test/components/MoteresponsColumnTest.tsx
@@ -8,6 +8,7 @@ import { render, screen } from "@testing-library/react";
 import { AktivEnhetContext } from "@/context/aktivEnhet/AktivEnhetContext";
 import React from "react";
 import {
+  DialogmoteDeltakerVarselType,
   DialogmoterDTO,
   DialogmoteStatus,
   SvarType,
@@ -68,6 +69,27 @@ const moteATKommerAGKommerBehandlerKommer = createDialogmote(
   SvarType.KOMMER
 );
 
+let moteATKommerAGKommerBehandlerIkkeSvart = createDialogmote(
+  veilederMock,
+  DialogmoteStatus.INNKALT,
+  new Date(),
+  { lestDato: new Date(), svar: SvarType.KOMMER },
+  { lestDato: new Date(), svar: SvarType.KOMMER },
+  SvarType.KOMMER
+);
+
+moteATKommerAGKommerBehandlerIkkeSvart = {
+  ...moteATKommerAGKommerBehandlerIkkeSvart,
+  behandler: {
+    varselList: [
+      {
+        varselType: DialogmoteDeltakerVarselType.INNKALT,
+        svar: [],
+      },
+    ],
+  },
+};
+
 describe("MineMoter", () => {
   afterEach(() => {
     nock.cleanAll();
@@ -119,5 +141,15 @@ describe("MineMoter", () => {
     renderMoreresponsColumn(moteATKommerAGKommerBehandlerKommer);
 
     expect(screen.getAllByText("Kommer")).to.have.length(3);
+  });
+
+  it("should render Kommer, Kommer, Ikke svart", () => {
+    stubDialogmoterVeilederidentApi(scope, veilederMock, [
+      moteATKommerAGKommerBehandlerIkkeSvart,
+    ]);
+    renderMoreresponsColumn(moteATKommerAGKommerBehandlerIkkeSvart);
+
+    expect(screen.getAllByText("Kommer")).to.have.length(2);
+    expect(screen.getAllByText("Ikke svart")).to.have.length(1);
   });
 });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Bug der vi ikke viste noe fra behandler dersom de ikke hadde svart. Før antok vi at dersom `behandlerSvar === undefined` så hadde ikke legen blitt kalt inn, men det var feil.

### Screenshots 📸✨

<img width="1483" alt="image" src="https://github.com/navikt/syfomoteoversikt/assets/37441744/5db74a94-737a-47bd-9db1-d89271ec3450">
