### PR TITLE
use nav chainguard docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY dist ./dist
 RUN npm install -g typescript
 RUN tsc --build
 
-FROM gcr.io/distroless/nodejs22-debian12
+FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/node:22-slim
 WORKDIR /syfomoteoversikt
 
 COPY --from=builder /syfomoteoversikt/package.json ./


### PR DESCRIPTION
Går fra dette:
<img width="216" height="279" alt="Skjermbilde 2026-02-05 kl  12 07 43" src="https://github.com/user-attachments/assets/d22d46d3-48c1-421f-bcfe-4054d3241968" />

Til dette:
<img width="243" height="325" alt="Skjermbilde 2026-02-05 kl  12 11 11" src="https://github.com/user-attachments/assets/8575c73a-2f54-41f8-8abf-536bac47cefc" />