### PR TITLE
IS: Remove polyfill dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@babel/polyfill": "7.12.1",
         "@grafana/faro-react": "1.19.0",
         "@grafana/faro-web-sdk": "1.19.0",
         "@grafana/faro-web-tracing": "1.19.0",
@@ -1692,16 +1691,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/polyfill": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
-      "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
-      "deprecated": "🚨 This package has been deprecated in favor of separate inclusion of a polyfill and regenerator-runtime (when needed). See the @babel/polyfill docs (https://babeljs.io/docs/en/babel-polyfill) for more information.",
-      "dependencies": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.4"
       }
     },
     "node_modules/@babel/preset-env": {
@@ -6691,13 +6680,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
-    },
-    "node_modules/core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-      "hasInstallScript": true
     },
     "node_modules/core-js-compat": {
       "version": "3.46.0",
@@ -13113,11 +13095,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "author": "Team DigiSyfo <digisyfo@nav.no>",
   "license": "ISC",
   "dependencies": {
-    "@babel/polyfill": "7.12.1",
     "@grafana/faro-react": "1.19.0",
     "@grafana/faro-web-sdk": "1.19.0",
     "@grafana/faro-web-tracing": "1.19.0",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import AppRouter from "./routers/AppRouter";
 import "@navikt/ds-css";
-import "./utils/globals";
 import "./styles/styles.css";
 import "./styles/style.css";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/src/utils/globals.js
+++ b/src/utils/globals.js
@@ -1,3 +1,0 @@
-if (!window._babelPolyfill) {
-  require("@babel/polyfill");
-}


### PR DESCRIPTION
## What

Remove the deprecated `@babel/polyfill` package and eliminate the `core-js@2` deprecation warning that came with it.

## Why

Running `npm install` produced two deprecation warnings:
- `@babel/polyfill@7.12.1` — deprecated in favour of separate `core-js` + `regenerator-runtime` inclusion
- `core-js@2.6.12` — transitive dependency pulled in by `@babel/polyfill`, no longer maintained

Since the app targets modern evergreen browsers, polyfills are not needed at all.

## Changes

- **`package.json`** — removed `@babel/polyfill` from dependencies
- **`src/utils/globals.js`** — deleted (only contained the `@babel/polyfill` guard)
- **`src/index.tsx`** — removed `import "./utils/globals"`

No changes to `.babelrc` or any other config.