### PR TITLE
IS-3855: Add virksomhet i møteoversikten på enheten

### DIFF
--- a/src/components/Mote.tsx
+++ b/src/components/Mote.tsx
@@ -13,7 +13,6 @@ interface Props {
   isSelected: (moteUuid: string) => boolean;
   toggleSelected: (moteUuid: string) => void;
   showVeileder: boolean;
-  showVirksomhet: boolean;
 }
 
 export default function Mote({
@@ -21,7 +20,6 @@ export default function Mote({
   isSelected,
   toggleSelected,
   showVeileder,
-  showVirksomhet,
 }: Props): ReactElement {
   const virksomhetQuery = useVirksomhetQuery(
     mote.arbeidsgiver.virksomhetsnummer
@@ -69,9 +67,7 @@ export default function Mote({
         <Table.DataCell textSize="small">{veilederNavn()}</Table.DataCell>
       )}
       <DialogmoteArbeidstakerColumns dialogmote={mote} />
-      {showVirksomhet && (
-        <Table.DataCell textSize="small">{virksomhetsNavn()}</Table.DataCell>
-      )}
+      <Table.DataCell textSize="small">{virksomhetsNavn()}</Table.DataCell>
       <Table.DataCell textSize="small">{statusTekst(mote)}</Table.DataCell>
       <MoteresponsColumn dialogmote={mote} />
     </Table.Row>

--- a/src/components/MoteTabell.tsx
+++ b/src/components/MoteTabell.tsx
@@ -20,7 +20,6 @@ interface Props {
   isSelected: (uuid: string) => boolean;
   toggleSelected: (uuid: string) => void;
   showVeileder: boolean;
-  showVirksomhet: boolean;
 }
 
 export default function MoteTabell({
@@ -28,7 +27,6 @@ export default function MoteTabell({
   isSelected,
   toggleSelected,
   showVeileder,
-  showVirksomhet,
 }: Props): ReactElement {
   return (
     <Table size="small" className="mb-8 bg-white">
@@ -41,9 +39,7 @@ export default function MoteTabell({
           )}
           <Table.HeaderCell scope="col">{texts.fnr}</Table.HeaderCell>
           <Table.HeaderCell scope="col">{texts.sykmeldt}</Table.HeaderCell>
-          {showVirksomhet && (
-            <Table.HeaderCell scope="col">{texts.virksomhet}</Table.HeaderCell>
-          )}
+          <Table.HeaderCell scope="col">{texts.virksomhet}</Table.HeaderCell>
           <Table.HeaderCell scope="col">{texts.status}</Table.HeaderCell>
           <Table.HeaderCell scope="col">{texts.respons}</Table.HeaderCell>
         </Table.Row>
@@ -56,7 +52,6 @@ export default function MoteTabell({
             isSelected={isSelected}
             toggleSelected={toggleSelected}
             showVeileder={showVeileder}
-            showVirksomhet={showVirksomhet}
           />
         ))}
       </Table.Body>

--- a/src/components/MoteoversiktEnhet.tsx
+++ b/src/components/MoteoversiktEnhet.tsx
@@ -113,7 +113,6 @@ export default function MoteoversiktEnhet(): ReactElement {
         isSelected={isSelected}
         toggleSelected={toggleSelected}
         showVeileder={true}
-        showVirksomhet={false}
       />
     </>
   );

--- a/src/sider/minemoter/MineMoter.tsx
+++ b/src/sider/minemoter/MineMoter.tsx
@@ -262,7 +262,6 @@ export default function MineMoter({
               isSelected={isSelected}
               toggleSelected={modifyDialogmoterUuids}
               showVeileder={false}
-              showVirksomhet={true}
             />
           </form>
         </>

--- a/test/components/EnhetensMoterTest.tsx
+++ b/test/components/EnhetensMoterTest.tsx
@@ -9,11 +9,12 @@ import {
   assertTableRows,
   daysFromToday,
 } from "../testUtil";
-import { describe, it, expect, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AktivEnhetContext } from "@/context/aktivEnhet/AktivEnhetContext";
 import {
   aktivEnhetMock,
+  arbeidsgiverMock,
   arbeidstakerMock,
   createDialogmote,
   veilederMock,
@@ -26,6 +27,7 @@ import {
   stubVeilederApi,
 } from "../mocks/stubVeilederApi";
 import { stubDialogmoterApi } from "../mocks/stubDialogmoterApi";
+import { stubVirksomhetApi } from "../mocks/stubVirksomhetApi.ts";
 
 const yesterday = daysFromToday(-1);
 const inTwoDays = daysFromToday(2);
@@ -58,6 +60,7 @@ const queryClient = new QueryClient();
 describe("EnhetensMoter", () => {
   beforeEach(() => {
     stubBrukernavnApi();
+    stubVirksomhetApi();
     stubDialogmoterApi(dialogmoterData);
     stubVeilederApi(veilederMock);
     stubAktivVeilederApi(veilederMock);
@@ -114,27 +117,28 @@ describe("EnhetensMoter", () => {
       "Veileder",
       "F.nr",
       "Sykmeldt",
+      "Virksomhet",
       "Status",
       "Respons fra deltakere",
     ]);
 
     const rows = screen.getAllByRole("row");
     assertTableRows(rows, [
-      "VelgMøtedatoVeilederF.nrSykmeldtStatusRespons fra deltakere",
+      "VelgMøtedatoVeilederF.nrSykmeldtVirksomhetStatusRespons fra deltakere",
       `${getDatoFraZulu(yesterday)}${veilederMock.fulltNavn()}${
         arbeidstakerMock.fnr
-      }${
-        arbeidstakerMock.navn
+      }${arbeidstakerMock.navn}${
+        arbeidsgiverMock.virksomhet
       }Referat ikke sendtArbeidstaker:KommerArbeidsgiver:Kommer`,
       `${getDatoFraZulu(inTwoDays)}${veilederMock.fulltNavn()}${
         arbeidstakerMock.fnr
-      }${
-        arbeidstakerMock.navn
+      }${arbeidstakerMock.navn}${
+        arbeidsgiverMock.virksomhet
       }Innkalt (med behandler)Arbeidstaker:KommerArbeidsgiver:KommerBehandler:Endring ønskes`,
       `${getDatoFraZulu(inFiveDays)}${veilederMock.fulltNavn()}${
         arbeidstakerMock.fnr
-      }${
-        arbeidstakerMock.navn
+      }${arbeidstakerMock.navn}${
+        arbeidsgiverMock.virksomhet
       }Endring sendtArbeidstaker:Ikke åpnetArbeidsgiver:Ikke åpnet`,
     ]);
   });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Lagt til virksomhet i møteoversikten på enhet

### Screenshots 📸✨
Før:
<img width="1381" height="748" alt="Skjermbilde 2026-05-15 kl  13 49 49" src="https://github.com/user-attachments/assets/b58b16cf-9cf9-4ead-9849-52e1ed5f043c" />

Etter:
<img width="1412" height="771" alt="Skjermbilde 2026-05-19 kl  14 00 29" src="https://github.com/user-attachments/assets/affa4285-3239-4f57-ab1b-37c1413ee5ca" />
