### PR TITLE
IS-4001: Fix infinite render + links

### DIFF
--- a/src/components/MoteoversiktEnhet.tsx
+++ b/src/components/MoteoversiktEnhet.tsx
@@ -79,6 +79,7 @@ export default function MoteoversiktEnhet(): ReactElement {
   };
 
   const filtrerteMoter = getFiltrerteMoter();
+
   return (
     <>
       <div className="flex items-center justify-between mb-2 bg-white sticky z-10 top-0 p-2 rounded shadow-[0_1px_3px_0px_rgba(0,0,0,0.5)]">

--- a/src/data/veiledere/veilederQueryHooks.ts
+++ b/src/data/veiledere/veilederQueryHooks.ts
@@ -3,6 +3,14 @@ import { get } from "@/api";
 import { SYFOVEILEDER_ROOT } from "@/utils/apiUrlUtil";
 import { useQueries, useQuery } from "@tanstack/react-query";
 
+const selectVeileder = (data: VeilederDTO): Veileder =>
+  new Veileder(data.ident, data.fornavn, data.etternavn);
+
+const selectVeiledere = (data: VeilederDTO[]): Veileder[] =>
+  data.map(
+    ({ ident, fornavn, etternavn }) => new Veileder(ident, fornavn, etternavn)
+  );
+
 export const veilederQueryKeys = {
   veileder: ["veileder"],
   enhet: ["enhet"],
@@ -19,7 +27,7 @@ export const useAktivVeileder = () => {
   return useQuery({
     queryKey: veilederQueryKeys.veileder,
     queryFn: fetchVeileder,
-    select: (data) => new Veileder(data.ident, data.fornavn, data.etternavn),
+    select: selectVeileder,
   });
 };
 
@@ -28,21 +36,23 @@ export const useVeilederQuery = (ident: string) => {
     queryKey: veilederQueryKeys.veilederByIdent(ident),
     queryFn: () => fetchVeilederByIdent(ident),
     enabled: !!ident,
-    select: (data) => new Veileder(data.ident, data.fornavn, data.etternavn),
+    select: selectVeileder,
   });
 };
 
 export const useVeiledereQuery = (identList: string[]) => {
-  const veiledereQueries = useQueries({
+  return useQueries({
     queries: identList.map((ident) => ({
       queryKey: veilederQueryKeys.veilederByIdent(ident),
-      select: (data: VeilederDTO) =>
-        new Veileder(data.ident, data.fornavn, data.etternavn),
+      queryFn: () => fetchVeilederByIdent(ident),
+      select: selectVeileder,
     })),
+    combine: (result) => {
+      return result
+        .map((query) => query.data)
+        .filter((veileder) => veileder !== undefined);
+    },
   });
-  return veiledereQueries
-    .map((query) => query.data)
-    .filter((veileder) => veileder !== undefined) as Veileder[];
 };
 
 export function useGetVeiledere(enhet: string) {
@@ -51,10 +61,6 @@ export function useGetVeiledere(enhet: string) {
     queryFn: () =>
       get<VeilederDTO[]>(`${SYFOVEILEDER_ROOT}/v3/veiledere?enhetNr=${enhet}`),
     enabled: !!enhet,
-    select: (data) =>
-      data.map(
-        (veileder) =>
-          new Veileder(veileder.ident, veileder.fornavn, veileder.etternavn)
-      ),
+    select: selectVeiledere,
   });
 }


### PR DESCRIPTION
Fikser et problem med infinite renders på dialogmøtesiden.

Egentlig skal Tanstack gjøre mye fancy magi for å fikse dette selv, gjennom noe som heter structural sharing. Det er med dette Tanstack håndterer cachingen sin og passer på at komponenter ikke rerendres på tvers. Men vi har en rar klassebasert løsning med `new Veileder(...)` som var stappet inn i `select` på hooken. Dette klarer ikke Tanstack å fikse med structural sharing, som gjorde at `select` fikk en ny funksjonsreferanse om og om igjen. Da rendret alt om og om igjen. Løsningen var å lage en egen definert funksjon for dette, slik at man kun fikk én referanse å forholde seg til.

Konsekvensene ble at lenkene ble svært vanskelige å trykke på, men dette bør fikse biffen :cut_of_meat: 